### PR TITLE
[bugfix] mismatched input

### DIFF
--- a/databoxlib/dbx.py
+++ b/databoxlib/dbx.py
@@ -79,7 +79,7 @@ def load_data(entity_catalog):
     # Request data from DataBOX for the Catalog
     print("Collecting data...")
     # os.chdir("~/")
-    subprocess.run(["/bin/python3", "/opt/trino/load_data.py", f"'{meta_data_sql}'"])
+    subprocess.run(["/bin/python3", "/opt/trino/load_data.py", f"{meta_data_sql}"])
 
     print("Convert RDS to Dataset...")
     import pyreadr


### PR DESCRIPTION
aspas extras em f"{meta_data_sql}" causavam o
seguinte bug: mismatched input ''select * from repo.yduqs.ABT_23_4parquet''